### PR TITLE
Handle zero-distance display for store cards

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -161,7 +161,7 @@ function renderStoreCards(stores) {
       const services = displayOrNA(store.Services);
       const sports = displayOrNA(store["Sports/TCG Available"]);
       const distance = getDistanceFromUser(store.lat, store.lng);
-      const distDisplay = distance ? `<p class="text-sm">📏 ${distance.toFixed(1)} km away</p>` : "";
+      const distDisplay = distance !== null ? `<p class="text-sm">📏 ${distance.toFixed(1)} km away</p>` : "";
 
       li.innerHTML = `
         <h4 class="font-bold text-lg">${name}</h4>


### PR DESCRIPTION
## Summary
- ensure store cards show distance when user is at the same location

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eabbbd33c8325b367c50c950ab220