### PR TITLE
Activate daily re-bake schedule (one file: site.yml)

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,36 @@
+name: site
+on:
+  push:
+    branches: [redesign]
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: redesign
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run bake
+      - run: npm test
+      - run: npm run build
+        env:
+          PUBLIC_MAPBOX_TOKEN: ${{ secrets.PUBLIC_MAPBOX_TOKEN }}
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+        env:
+          CI: 'true'
+      - name: Deploy to Cloudflare Pages
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=sportscardsnearme --branch=redesign


### PR DESCRIPTION
GitHub only runs scheduled workflows from the default branch. This adds the CI workflow file to main so the 9:00 UTC daily sheet-to-site rebuild fires. The workflow checks out and builds the **redesign** branch — it does not touch the legacy site served from main's root.

One file, no other changes. Approved by Nathan in-session 2026-07-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4awBv4ySndmf6QfjMPV8f