### PR TITLE
CI deploys to production branch (cutover prep)

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=sportscardsnearme --branch=redesign
+          command: pages deploy dist --project-name=sportscardsnearme --branch=main


### PR DESCRIPTION
One-line change: the daily pipeline deploys to the Pages production branch so the custom domain stays fresh once attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4awBv4ySndmf6QfjMPV8f