### PR TITLE
Codex hardening batch: lazy map, pin fallback, scoped payload, mobile shift, tag-filter e2e, 404 noindex

### DIFF
--- a/src/components/MapIsland.astro
+++ b/src/components/MapIsland.astro
@@ -27,7 +27,7 @@ const payload = JSON.stringify(toMapStores(stores, new Set(logoSlugs as string[]
     const raw = shell.querySelector('script[data-map-stores]')?.textContent ?? '[]';
     const stores = JSON.parse(raw) as MapStore[];
     const mode = shell.dataset['mapMode'];
-    const handle = mountMap(shell, stores, mode === 'store' ? { zoom: 14, pitch: 60 } : {});
+    const handle = await mountMap(shell, stores, mode === 'store' ? { zoom: 14, pitch: 60 } : {});
     if (!handle) continue;
     handle.onPinClick((slug) => {
       const card = document.querySelector(`[data-store-card="${slug}"]`);

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -10,8 +10,9 @@ interface Props {
   description: string;
   canonical?: string;
   ogImage?: string;
+  noindex?: boolean;
 }
-const { title, description, canonical, ogImage } = Astro.props;
+const { title, description, canonical, ogImage, noindex } = Astro.props;
 const canonicalURL = canonical ?? new URL(Astro.url.pathname, Astro.site).href;
 ---
 <!doctype html>
@@ -21,6 +22,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, Astro.site).href;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
+    {noindex && <meta name="robots" content="noindex" />}
     <link rel="canonical" href={canonicalURL} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" href="/favicon.ico" sizes="any" />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,7 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 ---
-<Base title="Not Found | Sports Cards Near Me" description="That page has been traded away.">
+<Base title="Not Found | Sports Cards Near Me" description="That page has been traded away." noindex>
   <h1 class="mt-24 text-6xl">Traded away.</h1>
   <p class="mt-4 text-muted">That page doesn't exist. <a href="/" class="text-prizm">Back to the directory</a>.</p>
 </Base>

--- a/src/pages/[province]/[city]/index.astro
+++ b/src/pages/[province]/[city]/index.astro
@@ -94,10 +94,10 @@ const sports = [...new Set(cityGroup.stores.flatMap((s) => s.sports))].sort();
     const count = document.querySelector<HTMLElement>('[data-results-count]');
     let handle: MapHandle | null = null;
 
-    const raw = document.querySelector('script[data-map-stores]')?.textContent ?? '[]';
+    const mapShell = document.querySelector<HTMLElement>('[data-city-map] .map-shell');
+    const raw = mapShell?.querySelector('script[data-map-stores]')?.textContent ?? '[]';
     const all = JSON.parse(raw) as MapStore[];
 
-    const mapShell = document.querySelector<HTMLElement>('[data-city-map] .map-shell');
     if (mapShell) {
       whenMapReady(mapShell, (h) => {
         handle = h;

--- a/src/pages/[province]/[city]/index.astro
+++ b/src/pages/[province]/[city]/index.astro
@@ -77,7 +77,7 @@ const sports = [...new Set(cityGroup.stores.flatMap((s) => s.sports))].sort();
     <ul role="list" class="space-y-4" data-store-list>
       {cityGroup.stores.map((store) => <StoreCard store={store} />)}
     </ul>
-    <div data-city-map class="md:sticky md:top-6 md:self-start">
+    <div data-city-map class="max-md:hidden md:sticky md:top-6 md:self-start">
       <MapIsland stores={cityGroup.stores} mode="city" height="560px" />
     </div>
   </div>
@@ -153,6 +153,5 @@ const sports = [...new Set(cityGroup.stores.flatMap((s) => s.sports))].sort();
         layout?.querySelector('[data-city-map]')?.classList.toggle('max-md:hidden', view === 'list');
       });
     }
-    document.querySelector('[data-city-map]')?.classList.add('max-md:hidden');
   </script>
 </Base>

--- a/src/scripts/map-core.ts
+++ b/src/scripts/map-core.ts
@@ -1,11 +1,10 @@
-import mapboxgl from 'mapbox-gl';
-import 'mapbox-gl/dist/mapbox-gl.css';
+import type { Map as MapboxMap, Marker as MapboxMarker } from 'mapbox-gl';
 import Supercluster from 'supercluster';
 import type { MapStore } from '../lib/map-data';
 import { createPinEl, createClusterEl } from './pins';
 
 export interface MapHandle {
-  map: mapboxgl.Map;
+  map: MapboxMap;
   setStores(stores: MapStore[]): void;
   flyTo(lng: number, lat: number, zoom?: number): void;
   onPinClick(cb: (slug: string) => void): void;
@@ -27,13 +26,22 @@ function centerOf(stores: MapStore[]): [number, number] {
   return [lng, lat];
 }
 
-export function mountMap(shell: HTMLElement, stores: MapStore[], opts: MountOpts = {}): MapHandle | null {
+export async function mountMap(
+  shell: HTMLElement,
+  stores: MapStore[],
+  opts: MountOpts = {},
+): Promise<MapHandle | null> {
   const token = import.meta.env.PUBLIC_MAPBOX_TOKEN;
   if (token === undefined || token === '') {
     shell.dataset['mapState'] = 'off';
     shell.style.removeProperty('height');
     return null;
   }
+  const [mapboxModule] = await Promise.all([
+    import('mapbox-gl'),
+    import('mapbox-gl/dist/mapbox-gl.css'),
+  ]);
+  const mapboxgl = mapboxModule.default;
   shell.dataset['mapState'] = 'on';
 
   const container = document.createElement('div');
@@ -58,7 +66,7 @@ export function mountMap(shell: HTMLElement, stores: MapStore[], opts: MountOpts
   }
 
   let clickCb: ((slug: string) => void) | null = null;
-  let markers: mapboxgl.Marker[] = [];
+  let markers: MapboxMarker[] = [];
   let index: Supercluster<{ store: MapStore }> | null = null;
   let current: MapStore[] = stores;
   let highlighted: string | null = null;

--- a/src/scripts/pins.ts
+++ b/src/scripts/pins.ts
@@ -17,6 +17,9 @@ function badgeFor(store: MapStore): HTMLElement {
     img.width = 20;
     img.height = 20;
     img.loading = 'lazy';
+    img.addEventListener('error', () => {
+      img.replaceWith(el('span', 'pin-badge', initialsOf(store.name)));
+    }, { once: true });
     return img;
   }
   return el('span', 'pin-badge', initialsOf(store.name));

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -42,6 +42,7 @@ test('map island degrades cleanly without a token', async ({ page }) => {
   page.on('pageerror', (e) => errors.push(String(e)));
   await page.goto('/');
   const shell = page.locator('#map-slot .map-shell');
+  await expect(shell).toHaveAttribute('data-map-state', /^(on|off)$/);
   const state = await shell.getAttribute('data-map-state');
   test.skip(state === 'on', 'token present in this build — off-state not exercised');
   await expect(shell).toHaveAttribute('data-map-state', 'off');
@@ -74,7 +75,9 @@ test.describe('nearest shops', () => {
   test.use({ geolocation: { latitude: 53.5461, longitude: -113.4938 }, permissions: ['geolocation'] });
   test('geolocate reveals a nearest-shops list with distances', async ({ page }) => {
     await page.goto('/');
-    const state = await page.locator('#map-slot .map-shell').getAttribute('data-map-state');
+    const shell = page.locator('#map-slot .map-shell');
+    await expect(shell).toHaveAttribute('data-map-state', /^(on|off)$/);
+    const state = await shell.getAttribute('data-map-state');
     test.skip(state !== 'on', 'geolocate wires with a token build');
     await page.locator('[data-geolocate]').first().click();
     await expect(page.locator('[data-nearest-list] a').first()).toBeVisible({ timeout: 10000 });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -62,6 +62,21 @@ test('city filters narrow the list', async ({ page }) => {
   await expect(count).toHaveText(String(before));
 });
 
+test('city tag filter toggles the result count', async ({ page }) => {
+  await page.goto('/alberta/edmonton/');
+  const errors: string[] = [];
+  page.on('pageerror', (error) => errors.push(String(error)));
+  const count = page.locator('[data-results-count]');
+  const initial = Number(await count.textContent());
+  const tag = page.locator('[data-filter-tag]').first();
+
+  await tag.click();
+  expect(Number(await count.textContent())).toBeLessThanOrEqual(initial);
+  await tag.click();
+  await expect(count).toHaveText(String(initial));
+  expect(errors).toEqual([]);
+});
+
 test('mobile map/list toggle switches panels', async ({ page, viewport }) => {
   test.skip((viewport?.width ?? 1280) > 500, 'mobile-only behavior');
   await page.goto(`/alberta/${first.citySlug}/`);

--- a/tests/unit/city-map-payload.test.ts
+++ b/tests/unit/city-map-payload.test.ts
@@ -12,3 +12,10 @@ it('reads the store payload from the city map island', () => {
   );
   expect(cityPage).not.toContain("document.querySelector('script[data-map-stores]')");
 });
+
+it('renders the city map hidden on mobile without a post-load mutation', () => {
+  expect(cityPage).toMatch(/<div data-city-map class="[^"]*\bmax-md:hidden\b[^"]*">/);
+  expect(cityPage).not.toContain(
+    "document.querySelector('[data-city-map]')?.classList.add('max-md:hidden');",
+  );
+});

--- a/tests/unit/city-map-payload.test.ts
+++ b/tests/unit/city-map-payload.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { expect, it } from 'vitest';
+
+const cityPage = readFileSync(
+  new URL('../../src/pages/[province]/[city]/index.astro', import.meta.url),
+  'utf8',
+);
+
+it('reads the store payload from the city map island', () => {
+  expect(cityPage).toMatch(
+    /const mapShell = document\.querySelector<HTMLElement>\('\[data-city-map\] \.map-shell'\);\s+const raw = mapShell\?\.querySelector\('script\[data-map-stores\]'\)/,
+  );
+  expect(cityPage).not.toContain("document.querySelector('script[data-map-stores]')");
+});

--- a/tests/unit/map-core.test.ts
+++ b/tests/unit/map-core.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { afterEach, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  vi.doUnmock('mapbox-gl');
+});
+
+it('does not load mapbox-gl when the public token is empty', async () => {
+  vi.stubEnv('PUBLIC_MAPBOX_TOKEN', '');
+  let mapboxLoaded = false;
+  vi.doMock('mapbox-gl', () => {
+    mapboxLoaded = true;
+    return { default: {} };
+  });
+
+  const { mountMap } = await import('../../src/scripts/map-core');
+  const shell = document.createElement('div');
+  const handle = await mountMap(shell, []);
+
+  expect(handle).toBeNull();
+  expect(shell.dataset['mapState']).toBe('off');
+  expect(mapboxLoaded).toBe(false);
+});

--- a/tests/unit/pins.test.ts
+++ b/tests/unit/pins.test.ts
@@ -39,3 +39,13 @@ it('createPinEl uses a logo image when the store has one', () => {
   expect(img?.getAttribute('src')).toBe(`/logos/${store.slug}.webp`);
   expect(elp.querySelector('span.pin-badge')).toBeNull();
 });
+
+it('createPinEl replaces a failed logo image with the initials badge', () => {
+  const elp = createPinEl({ ...store, logo: true });
+  const img = elp.querySelector<HTMLImageElement>('img.pin-badge-img');
+
+  img?.dispatchEvent(new Event('error'));
+
+  expect(elp.querySelector('img.pin-badge-img')).toBeNull();
+  expect(elp.querySelector('span.pin-badge')?.textContent).toBe('203');
+});

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { expect, it } from 'vitest';
+
+const readSource = (path: string): string =>
+  readFileSync(new URL(path, import.meta.url), 'utf8');
+
+it('adds noindex robots metadata to the 404 page only', () => {
+  const layout = readSource('../../src/layouts/Base.astro');
+  const notFoundPage = readSource('../../src/pages/404.astro');
+  const homePage = readSource('../../src/pages/index.astro');
+
+  expect(layout).toMatch(/noindex\s*&&\s*<meta name="robots" content="noindex" \/>/);
+  expect(notFoundPage).toMatch(/<Base\b[^>]*\bnoindex\b[^>]*>/);
+  expect(homePage).not.toMatch(/<Base\b[^>]*\bnoindex\b[^>]*>/);
+});


### PR DESCRIPTION
Six commits from the Codex work order (docs/handoffs/2026-07-12-codex.md), all cross-model reviewed and approved by Fable in two waves. Rebased onto redesign at 25594cc; Base.astro overlap verified by eye (4 additive lines, clean merge).

Gates on the rebased head, tokenless AND with token: 59/59 unit, tsc --noEmit clean, 775-page build, e2e 31 passed / 3 conditional skips, 0 failed.

Known riders (ledgered, non-blocking): tests/unit/seo.test.ts and tests/unit/city-map-payload.test.ts assert on source formatting — future false-fails are test brittleness, planned conversion to dist assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4awBv4ySndmf6QfjMPV8f